### PR TITLE
finished restful label controllers and routes with dynamic segment implementation

### DIFF
--- a/axxon/src/app/api/board/[boardId]/labels/[labelId]/route.ts
+++ b/axxon/src/app/api/board/[boardId]/labels/[labelId]/route.ts
@@ -1,0 +1,14 @@
+import {PATCH as updateLabel, DELETE as deleteLabel, getLabelByIdController as getLabelById } from '@/lib/controllers/labels/labelControllers';
+import type { NextRequest } from 'next/server';
+
+export async function PATCH(req: NextRequest, context: { params: { boardId: string; labelId: string } }) {
+  return updateLabel(req, context.params);
+}
+
+export async function DELETE(req: NextRequest, context: { params: { boardId: string; labelId: string } }) {
+  return deleteLabel(req, context.params);
+}
+
+export async function GET(req: NextRequest, context: { params: { boardId: string; labelId: string } }) {
+  return getLabelById(req, context.params);
+}

--- a/axxon/src/app/api/board/[boardId]/labels/route.ts
+++ b/axxon/src/app/api/board/[boardId]/labels/route.ts
@@ -1,0 +1,10 @@
+import { POST as createLabel, GET as listLabels } from '@/lib/controllers/labels/labelControllers';
+import type { NextRequest } from 'next/server';
+
+export async function POST(req: NextRequest, context: { params: { boardId: string} }) {
+  return createLabel(req, context.params);
+}
+
+export async function GET(req: NextRequest, context: { params: { boardId: string } }) {
+  return listLabels(req, context.params);
+}

--- a/axxon/src/lib/controllers/labels/labelControllers.ts
+++ b/axxon/src/lib/controllers/labels/labelControllers.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Labels } from '@/lib/models/labels';
+import type { CreateLabelData, UpdateLabelData } from '@/lib/models/types/labelTypes';
+
+// Create Label (POST /board/[boardId]/labels)
+export async function POST(req: NextRequest, params: { boardId: string } ) {
+  try {
+    const board_id = Number(params.boardId);
+    const body = await req.json();
+
+    const data: CreateLabelData = { ...body, board_id };
+    const label = await Labels.createLabel(data);
+
+    return NextResponse.json(label, { status: 201 });
+  } catch (error) {
+    console.error('[CREATE_LABEL_ERROR]', error);
+    return NextResponse.json({ error: 'Failed to create label' }, { status: 500 });
+  }
+}
+
+// List Labels in Board (GET /board/[boardId]/labels)
+export async function GET(_req: NextRequest, params: { boardId: string } ) {
+  try {
+    const board_id = Number(params.boardId);
+    const labels = await Labels.listAllLabelsInBoard({ board_id });
+
+    return NextResponse.json(labels, { status: 200 });
+  } catch (error) {
+    console.error('[LIST_LABELS_ERROR]', error);
+    return NextResponse.json({ error: 'Failed to list labels' }, { status: 500 });
+  }
+}
+
+// Update Label (PATCH /board/[boardId]/labels/[labelId])
+export async function PATCH(req: NextRequest, params: { boardId: string; labelId: string } ) {
+  try {
+    const id = Number(params.labelId);
+    const board_id = Number(params.boardId);
+    const body = await req.json();
+
+    const data: UpdateLabelData = { ...body, id, board_id };
+    const label = await Labels.updateLabel(data);
+
+    return NextResponse.json(label, { status: 200 });
+  } catch (error) {
+    console.error('[UPDATE_LABEL_ERROR]', error);
+    return NextResponse.json({ error: 'Failed to update label' }, { status: 500 });
+  }
+}
+
+// Delete Label (DELETE /board/[boardId]/labels/[labelId])
+export async function DELETE(_req: NextRequest, params: { boardId: string; labelId: string } ) {
+  try {
+    const id = Number(params.labelId);
+    const deleted = await Labels.deleteLabel({ id });
+
+    return NextResponse.json({ deleted }, { status: 200 });
+  } catch (error) {
+    console.error('[DELETE_LABEL_ERROR]', error);
+    return NextResponse.json({ error: 'Failed to delete label' }, { status: 500 });
+  }
+}
+
+// Get Label by ID (GET /board/[boardId]/labels/[labelId])
+export async function getLabelByIdController(_req: NextRequest, params: { boardId: string; labelId: string } ) {
+  try {
+    const id = Number(params.labelId);
+    const label = await Labels.getLabelById({ id });
+
+    return NextResponse.json(label, { status: 200 });
+  } catch (error) {
+    console.error('[GET_LABEL_BY_ID_ERROR]', error);
+    return NextResponse.json({ error: 'Failed to retrieve label' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
# Add Label Controllers and Dynamic Routes

## Summary

This PR adds full CRUD functionality for Labels, scoped under a specific Board.

## Changes Made

- Created label controllers in `controllers/labelController.ts`:
  - `createLabel`
  - `listLabels`
  - `getLabelById`
  - `updateLabel`
  - `deleteLabel`

- Added dynamic API routes:
  - `POST /api/board/[boardId]/labels` – Create a label
  - `GET /api/board/[boardId]/labels` – Get all labels for a board
  - `GET /api/board/[boardId]/labels/[labelId]` – Get label by ID
  - `PATCH /api/board/[boardId]/labels/[labelId]` – Update a label
  - `DELETE /api/board/[boardId]/labels/[labelId]` – Delete a label

## Notes

- All route handlers extract dynamic segments via `context.params` only, keeping controllers separated from routing logic.
- Labels are stored with a `board_id` foreign key for proper scoping.

